### PR TITLE
Remove early return behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.3
+
+ - Remove early return feature to avoid extra selects
+
 ## 0.0.2
 
  - Actually include source code in gem :-)

--- a/lib/active_record_filter/filter_executer.rb
+++ b/lib/active_record_filter/filter_executer.rb
@@ -29,8 +29,6 @@ module ActiveRecordFilter
 
       component_classes.each do |component_class|
         relation = apply_filter(relation, component_class, filter_object)
-
-        break if relation.empty?
       end
 
       relation

--- a/lib/active_record_filter/version.rb
+++ b/lib/active_record_filter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordFilter
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end

--- a/test/test_active_record_filter.rb
+++ b/test/test_active_record_filter.rb
@@ -96,13 +96,6 @@ class ActiveRecordFilterTest < Minitest::Test
     assert_equal filter.at_step(1).component.class, TestComponentB
   end
 
-  def test_early_return
-    filter_object = FilterObject.new(query: 'ohno', min_value: 5)
-    filter        = TestFilterAC.execute(filter_object)
-
-    assert_equal filter.applied_filters.count, 1
-  end
-
   def test_applied_filters
     filter_object = FilterObject.new(query: 'test')
     filter        = TestFilterAB.execute(filter_object)


### PR DESCRIPTION
Early return is not worth it, since it runs the relation query at each filter step.