### PR TITLE
Add support for activerecord version 6

### DIFF
--- a/active_record_filter.gemspec
+++ b/active_record_filter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'activerecord', '>= 4', '< 6'
+  s.add_runtime_dependency 'activerecord', '>= 4', '< 7'
   s.add_development_dependency 'rake', '>= 10.0'
   s.add_development_dependency 'minitest', '< 6'
   s.add_development_dependency 'simplecov', '~> 0.17.1'


### PR DESCRIPTION
I've ran the spec locally with activerecord (6.0.3.1) ✅ 

```ruby
# Running:

.........

Finished in 0.025282s, 355.9845 runs/s, 672.4152 assertions/s.

9 runs, 17 assertions, 0 failures, 0 errors, 0 skips
```